### PR TITLE
Setting psk.txt permission to 0600

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
   notify:
   - racoon restart
 
-- template: src=templates/psk.txt dest=/etc/racoon/psk.txt
+- template: src=templates/psk.txt dest=/etc/racoon/psk.txt mode=0600
   when: ipsec_mode == 'ike'
   notify:
   - racoon restart


### PR DESCRIPTION
This solves a permission issue which prevents psk.txt from being used by racoon. This has maybe something to do with a newer ipsec/racoon version.

Affected version:
ipsec-tools 0.8.2

Error-log:
ERROR: /etc/racoon/psk.txt has weak file permission
ERROR: failed to open pre_share_key file /etc/racoon/psk.txt